### PR TITLE
Init tc mirred

### DIFF
--- a/bin/docker-tc.sh
+++ b/bin/docker-tc.sh
@@ -86,6 +86,10 @@ while read DOCKER_EVENT; do
             netm_add_rule "corrupt" "$CORRUPT" "corrupt"
             netm_add_rule "duplicate" "$DUPLICATION" "duplicate"
             netm_add_rule "reorder" "$REORDERING" "reorder"
+            if [[ -n "$NETM_OPTIONS" || -n "$LIMIT" ]]; then
+                echo "[DEBUG] set up mirred"
+                qdisc_set_mirred "$NETWORK_INTERFACE_NAME"
+            fi
             OPTIONS_LOG=$(echo "$OPTIONS_LOG" | sed 's/[, ]*$//')
             log "Set ${OPTIONS_LOG} on $NETWORK_INTERFACE_NAME"
             qdisc_netm "$NETWORK_INTERFACE_NAME" $NETM_OPTIONS

--- a/bin/tc-common.sh
+++ b/bin/tc-common.sh
@@ -32,6 +32,9 @@ qdisc_tbf() {
     qdisc_next
 }
 qdisc_set_mirred() {
+    # clear previous configuration
+    tc qdisc del dev ifb0 root
+    # add new configuration
     IF="$1"
     tc qdisc add dev "$IF" ingress
     echo "[DEBUG] tc qdisc add dev "$IF" ingress"

--- a/bin/tc-common.sh
+++ b/bin/tc-common.sh
@@ -4,9 +4,11 @@ QDISC_HANDLE=
 tc_init() {
     QDISC_ID=1
     QDISC_HANDLE="root handle $QDISC_ID:"
+    ip link set dev ifb0 up
 }
 qdisc_del() {
     tc qdisc del dev "$1" root
+    tc qdisc del dev ifb0 root
 }
 qdisc_next() {
     QDISC_HANDLE="parent $QDISC_ID: handle $((QDISC_ID+1)):"
@@ -18,6 +20,7 @@ qdisc_netm() {
     IF="$1"
     shift
     tc qdisc add dev "$IF" $QDISC_HANDLE netem $@
+    tc qdisc add dev ifb0 $QDISC_HANDLE netem $@
     qdisc_next
 }
 # http://man7.org/linux/man-pages/man8/tc-tbf.8.html
@@ -25,5 +28,13 @@ qdisc_tbf() {
     IF="$1"
     shift
     tc qdisc add dev "$IF" $QDISC_HANDLE tbf burst 5kb latency 50ms $@
+    tc qdisc add dev ifb0 $QDISC_HANDLE tbf burst 5kb latency 50ms $@
     qdisc_next
+}
+qdisc_set_mirred() {
+    IF="$1"
+    tc qdisc add dev "$IF" ingress
+    echo "[DEBUG] tc qdisc add dev "$IF" ingress"
+    tc filter add dev "$IF" parent ffff: protocol ip u32 match u32 0 0 action mirred egress redirect dev ifb0
+    echo "[DEBUG] tc filter add dev "$IF" parent ffff: protocol ip u32 match u32 0 0 action mirred egress redirect dev ifb0"
 }


### PR DESCRIPTION
This only works with 1 ifb (ifb0) for now, which means only 1 container's network can be tweaked with tc.

Set up [tc-mirred](https://man7.org/linux/man-pages/man8/tc-mirred.8.html) for the container where the rule is applied, so both egress and ingress traffic can have the same limits.

Ideally the `ifbX` should have a dynamically incrementing `X`, and the `ifbX-vethY` pairs should be tracked, so whenever `vethY` changes, the same rule should be applied on the related matching pair `ifbX`.

This matching pair list should be updated if a test ends. Currently the implementation only watches the docker start events, but not the stops. The `ifbX`'s `X` is currently `0` and `1` (as this is what the host have), so this is another task to solve to dynamically add/remove these on the host.

For now this seems to work for 2 containers (`A`, `B`), where `A` has tc limit and `B` does not. Both the egress and ingress traffic of `A` is limited, so it shows decreased quality from `B` and `B` also gets a decreased quality from `A`.

## Test plan

1. stop and remove previous docker-tc: `docker stop docker-tc && docker rm docker-tc`
2. build new img by running `docker build . -t nandito/docker-tc` in the root folder of this repo
3. start container
   ```sh
   docker run -d \
       --name docker-tc \
       --network host \
       --cap-add NET_ADMIN \
       --restart always \                             
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v /var/docker-tc:/var/docker-tc \
       nandito/docker-tc
   ```